### PR TITLE
Change ClientLibrary.wait_for_lld_connected() to ClientLibrary.is_system_ready(wait=True)

### DIFF
--- a/CMLNetKit/AutoNetKit/CMLNetKit.py
+++ b/CMLNetKit/AutoNetKit/CMLNetKit.py
@@ -287,7 +287,7 @@ class CMLNetKit(object):
         cl = ClientLibrary(url="https://" + self._cmlnetkitconfig.host, username=self._cmlnetkitconfig.username,
                            password=self._cmlnetkitconfig.password,
                            ssl_verify=self._cmlnetkitconfig.ssl_verify)
-        cl.wait_for_lld_connected()
+        cl.is_system_ready(wait=True)
         labs = cl.all_labs()
         print('\nLab ID\tLab Title')
         for lab in labs:

--- a/CMLNetKit/AutoNetKit/CMLNetKit.py
+++ b/CMLNetKit/AutoNetKit/CMLNetKit.py
@@ -119,7 +119,7 @@ class CMLNetKit(object):
         cl = ClientLibrary(url="https://" + self._cmlnetkitconfig.host, username=self._cmlnetkitconfig.username,
                            password=self._cmlnetkitconfig.password,
                            ssl_verify=self._cmlnetkitconfig.ssl_verify)
-        cl.wait_for_lld_connected()
+        cl.is_system_ready(wait=True)
         try:
             self.lab_handler = cl.join_existing_lab(self._cmlnetkitconfig.lab_id)
             self.lab_conf = yaml.safe_load(self.lab_handler.download())
@@ -140,7 +140,7 @@ class CMLNetKit(object):
         cl = ClientLibrary(url="https://" + self._cmlnetkitconfig.host, username=self._cmlnetkitconfig.username,
                            password=self._cmlnetkitconfig.password,
                            ssl_verify=self._cmlnetkitconfig.ssl_verify)
-        cl.wait_for_lld_connected()
+        cl.is_system_ready(wait=True)
         self.lab_conf = cl.import_lab(topology=yaml.dump(self.lab_conf), title=self.lab_conf["lab"]["title"])
 
     def update_bridge(self):


### PR DESCRIPTION
ClientLibrary.wait_for_lld_connected() was deprecated as of virl2_client v2.1.0-rc1 (https://github.com/CiscoDevNet/virl2-client/releases/tag/v2.1.0-rc.1).